### PR TITLE
Apply least-privilege GITHUB_TOKEN permissions (follow-up)

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -10,13 +10,14 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
-  actions: read
+  contents: read
 
 jobs:
   compare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -11,12 +11,14 @@ on:
 # `contents: read and write` and `pull requests: read and write` and pass it to the action.
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: grafana/plugin-actions/create-plugin-update@main # zizmor: ignore[unpinned-uses] provided by grafana
         # Uncomment to use a fine-grained personal access token instead of default github token


### PR DESCRIPTION
Closes #48

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI configuration update.

### What was changed?

- Enforced read-only workflow-level `GITHUB_TOKEN` permissions in:
  - `.github/workflows/bundle-stats.yml`
  - `.github/workflows/cp-update.yml`
- Scoped write permissions to only the jobs that require them:
  - `bundle-stats.yml` `compare` job: `contents: write`, `pull-requests: write`
  - `cp-update.yml` `release` job: `contents: write`, `pull-requests: write`
- Avoided unrelated CI behavior changes from the previous attempt to keep this PR narrowly focused on permissions hardening.

Implementation plan reference: https://github.com/reductstore/reduct-grafana/issues/48#issuecomment-4306161690

### Related issues

- https://github.com/reductstore/reduct-grafana/issues/48
- Supersedes closed attempt: https://github.com/reductstore/reduct-grafana/pull/49

### Does this PR introduce a breaking change?

No product/API breaking change expected. This only narrows workflow token scopes while preserving required write access for release/update jobs.

### Other information:

Validation run locally:
- `npm run lint`
