### PR TITLE
chore: bump Grafana base image to 12.4.3

### DIFF
--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -7,7 +7,7 @@ services:
       context: .
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
-        grafana_version: ${GRAFANA_VERSION:-12.0.1}
+        grafana_version: ${GRAFANA_VERSION:-12.4.3}
         development: ${DEVELOPMENT:-false}
         anonymous_auth_enabled: ${ANONYMOUS_AUTH_ENABLED:-true}
     ports:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-05-19
+
 ### Changed
 
 - Update the Grafana Docker base image and local development default to Grafana 12.4.3, [PR-57](https://github.com/reductstore/reduct-grafana/pull/57)
-
-## [1.2.1] - 2026-05-19
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update the Grafana Docker base image and local development default to Grafana 12.4.3, [PR-57](https://github.com/reductstore/reduct-grafana/pull/57)
+
 ## [1.2.1] - 2026-05-19
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/grafana/grafana:12.0.2
+FROM docker.io/grafana/grafana:12.4.3
 
 USER root
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Maintenance / dependency update

### What was changed?

- bump the published Docker image base from `grafana/grafana:12.0.2` to `grafana/grafana:12.4.3`
- bump the local development default Grafana version from `12.0.1` to `12.4.3` in `.config/docker-compose-base.yaml`
- keep runtime and development defaults aligned on the latest Grafana 12.4 release

### Related issues

None linked.

### Does this PR introduce a breaking change?

No. This only updates the Grafana base image within the existing 12.x line.

### Other information:

- Noticed `12.4.3` as the latest available non-security Grafana 12.4 tag for both `grafana/grafana` and `grafana/grafana-enterprise`.
- No code changes to the datasource plugin itself.
